### PR TITLE
fix: increase timeout for aggregator API

### DIFF
--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -368,7 +368,8 @@ export function AggregatorStack({ stack, app }) {
         },
         bind: [
           aggregatorPrivateKey
-        ]
+        ],
+        timeout: '30 seconds'
       },
       deadLetterQueue: aggregatorInclusionStoreHandleInsertToPieceAcceptDLQ.cdk.queue,
       cdk: {

--- a/stacks/api-stack.js
+++ b/stacks/api-stack.js
@@ -76,6 +76,7 @@ export function ApiStack({ app, stack }) {
     customDomain: aggregatorApiCustomDomain,
     defaults: {
       function: {
+        timeout: '30 seconds',
         environment: {
           NAME: 'aggregator-api',
           VERSION: pkg.version,


### PR DESCRIPTION
All handler executions for inclusion store insert are timing out at 10s. The lambda invokes the aggregator service UCAN service, but this is also set to timeout at the default 10s.

<img width="785" alt="Screenshot 2024-07-17 at 11 42 46" src="https://github.com/user-attachments/assets/008e9d41-89f5-4261-ae6e-60227363e801">

This PR changes the timeout for the insert handler lambda and the aggregator UCAN service to the max (30s) to see if it resolves the issue.