### PR TITLE
feat: add buffer store LRU cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15843,6 +15843,7 @@
         "@web3-storage/filecoin-api": "^7.2.0",
         "@web3-storage/filecoin-client": "^3.3.3",
         "fzstd": "^0.1.0",
+        "lru-cache": "^11.0.0",
         "multiformats": "12.0.1",
         "p-all": "^5.0.0",
         "p-retry": "^5.1.2",
@@ -15946,6 +15947,14 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "packages/core/node_modules/lru-cache": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "packages/core/node_modules/multiformats": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "@web3-storage/filecoin-api": "^7.2.0",
     "@web3-storage/filecoin-client": "^3.3.3",
     "fzstd": "^0.1.0",
+    "lru-cache": "^11.0.0",
     "multiformats": "12.0.1",
     "p-all": "^5.0.0",
     "p-retry": "^5.1.2",

--- a/packages/functions/src/aggregator/handle-buffer-queue-message.js
+++ b/packages/functions/src/aggregator/handle-buffer-queue-message.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/serverless'
 
-import { createClient as createBufferStoreClient } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
+import { createClient as createBufferStoreClient, withCache as withBufferStoreCache } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
 import { createClient as createBufferQueueClient, decodeMessage } from '@w3filecoin/core/src/queue/buffer-queue.js'
 import { createClient as createAggregateOfferQueueClient } from '@w3filecoin/core/src/queue/aggregate-offer-queue.js'
 import * as aggregatorEvents from '@web3-storage/filecoin-api/aggregator/events'
@@ -83,11 +83,12 @@ function getContext () {
   } = getEnv()
 
   return {
-    bufferStore: 
+    bufferStore: withBufferStoreCache(
       createBufferStoreClient(
         { region: bufferStoreBucketRegion },
         { name: bufferStoreBucketName }
-      ),
+      )
+    ),
     bufferQueue: createBufferQueueClient(
       { region: bufferQueueRegion },
       { queueUrl: bufferQueueUrl }

--- a/packages/functions/src/aggregator/handle-buffer-queue-message.js
+++ b/packages/functions/src/aggregator/handle-buffer-queue-message.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/serverless'
 
-import { createClient as createBufferStoreClient } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
+import { createClient as createBufferStoreClient, withCache as withBufferStoreCache } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
 import { createClient as createBufferQueueClient, decodeMessage } from '@w3filecoin/core/src/queue/buffer-queue.js'
 import { createClient as createAggregateOfferQueueClient } from '@w3filecoin/core/src/queue/aggregate-offer-queue.js'
 import * as aggregatorEvents from '@web3-storage/filecoin-api/aggregator/events'
@@ -83,9 +83,11 @@ function getContext () {
   } = getEnv()
 
   return {
-    bufferStore: createBufferStoreClient(
-      { region: bufferStoreBucketRegion },
-      { name: bufferStoreBucketName }
+    bufferStore: withBufferStoreCache(
+      createBufferStoreClient(
+        { region: bufferStoreBucketRegion },
+        { name: bufferStoreBucketName }
+      )
     ),
     bufferQueue: createBufferQueueClient(
       { region: bufferQueueRegion },

--- a/packages/functions/src/aggregator/handle-buffer-queue-message.js
+++ b/packages/functions/src/aggregator/handle-buffer-queue-message.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/serverless'
 
-import { createClient as createBufferStoreClient, withCache as withBufferStoreCache } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
+import { createClient as createBufferStoreClient } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
 import { createClient as createBufferQueueClient, decodeMessage } from '@w3filecoin/core/src/queue/buffer-queue.js'
 import { createClient as createAggregateOfferQueueClient } from '@w3filecoin/core/src/queue/aggregate-offer-queue.js'
 import * as aggregatorEvents from '@web3-storage/filecoin-api/aggregator/events'
@@ -83,12 +83,11 @@ function getContext () {
   } = getEnv()
 
   return {
-    bufferStore: withBufferStoreCache(
+    bufferStore: 
       createBufferStoreClient(
         { region: bufferStoreBucketRegion },
         { name: bufferStoreBucketName }
-      )
-    ),
+      ),
     bufferQueue: createBufferQueueClient(
       { region: bufferQueueRegion },
       { queueUrl: bufferQueueUrl }

--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -66,11 +66,11 @@ export function AggregatorStack({ stack, app }) {
         // Guarantee exactly-once processing
         // (Note: maximum 10 batch)
         fifo: true,
-        // During the deduplication interval (5 minutes), Amazon SQS treats
+        // During the deduplication interval (10 minutes), Amazon SQS treats
         // messages that are sent with identical body content
         contentBasedDeduplication: true,
         queueName: `${bufferQueueName}.fifo`,
-        visibilityTimeout: Duration.minutes(5)
+        visibilityTimeout: Duration.minutes(10)
       }
     },
   })
@@ -191,7 +191,7 @@ export function AggregatorStack({ stack, app }) {
         aggregatorBufferStoreBucket,
         aggregateOfferQueue
       ],
-      timeout: '5 minutes',
+      timeout: '10 minutes',
       memorySize: '2 GB'
     },
     deadLetterQueue: bufferQueueDLQ.cdk.queue,
@@ -199,7 +199,7 @@ export function AggregatorStack({ stack, app }) {
       eventSource: {
         // we can reduce most buffers possible at same time to avoid large buffers to create huge congestion on the queue while being processed.
         // also makes less lambda calls and decreases overall execution time.
-        batchSize: 10,
+        batchSize: 5,
         // allow reporting partial failures
         reportBatchItemFailures: true,
       },

--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -66,11 +66,11 @@ export function AggregatorStack({ stack, app }) {
         // Guarantee exactly-once processing
         // (Note: maximum 10 batch)
         fifo: true,
-        // During the deduplication interval (15 minutes), Amazon SQS treats
+        // During the deduplication interval (5 minutes), Amazon SQS treats
         // messages that are sent with identical body content
         contentBasedDeduplication: true,
         queueName: `${bufferQueueName}.fifo`,
-        visibilityTimeout: Duration.minutes(15)
+        visibilityTimeout: Duration.minutes(5)
       }
     },
   })
@@ -191,7 +191,7 @@ export function AggregatorStack({ stack, app }) {
         aggregatorBufferStoreBucket,
         aggregateOfferQueue
       ],
-      timeout: '15 minutes',
+      timeout: '5 minutes',
       memorySize: '2 GB'
     },
     deadLetterQueue: bufferQueueDLQ.cdk.queue,

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -9,10 +9,8 @@ export async function waitForStoreOperationOkResult (fn, verifyResFn) {
   return await pRetry(async () => {
     const r = await fn()
     if (!verifyResFn(r)) {
-      if (r.error) {
-        throw r.error
-      }
-      throw new Error('result did not satisfy verifcation function')
+      console.error('wait result:', r)
+      throw (r.error ?? new Error('result did not satisfy verifcation function'))
     }
 
     return r


### PR DESCRIPTION
Adds a LRU cache to the buffer store.

Typically the same lambda instance is invoked multiple times to create the aggregate. Every time it is executed it needs to load details of all the currently buffered pieces. This PR adds an LRU cache to speed up the process.